### PR TITLE
13 investigate some microoptimizations

### DIFF
--- a/src/Conway.Core/Grid.fs
+++ b/src/Conway.Core/Grid.fs
@@ -71,12 +71,12 @@ type ConwayGrid private (startingGrid: int<CellStatus> array2d) =
         let activeBuffer = this.Buffers[activeIndex]
         let passiveBuffer = this.Buffers[passiveIndex]
 
-        use activePtr = fixed &activeBuffer.[0, 0]
-        use passivePtr = fixed &passiveBuffer.[0, 0]
-
         let rows = Array2D.length1 activeBuffer
         let cols = Array2D.length2 activeBuffer
         let lastCol = cols - 2
+
+        use activePtr = fixed &activeBuffer.[0, 0]
+        use passivePtr = fixed &passiveBuffer.[0, 0]
 
         Parallel.For(
             1,


### PR DESCRIPTION
The micro-optimisations did actually help, shaving off a total of 15 ms from the processing time of a 10000 x 10000 grid. Some might have been more important than others, but having done them all, we might as well merge them all, as none of the micro-optimisations have a significant impact on other code metrics (eg maintainability, complexity etc)